### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/zsh-guide/book.toml
+++ b/zsh-guide/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Jeffrey Serio"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Zsh Guide"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10